### PR TITLE
feat: allow canary

### DIFF
--- a/packages/polar-nextjs/package.json
+++ b/packages/polar-nextjs/package.json
@@ -44,7 +44,7 @@
 			"--loader=ts-node/esm"
 		]
 	},
-	"peerDependencies": {
-		"next": "^15.0.0"
-	}
+  "peerDependencies": {
+    "next": "^15.0.0 || ^15.2.0-canary.*"
+  }
 }


### PR DESCRIPTION
I'm only allowing 15.2.0 as these are the versions I'm using and I've encountered no issues so far.
Allowing canary.* because I think users assume that, all canary versions are not stable, so issues are expected.