### PR TITLE
fix: remove duplicated CustomerPortalConfig import

### DIFF
--- a/packages/polar-nuxt/src/runtime/server/webhookHandler.ts
+++ b/packages/polar-nuxt/src/runtime/server/webhookHandler.ts
@@ -8,12 +8,6 @@ import {
 } from "@polar-sh/sdk/webhooks";
 import { type H3Event, createError, getHeader, readBody } from "h3";
 
-export interface CustomerPortalConfig {
-	accessToken: string;
-	server?: "sandbox" | "production";
-	getCustomerId: (event: H3Event) => Promise<string>;
-}
-
 export const Webhooks = ({
 	webhookSecret,
 	onPayload,


### PR DESCRIPTION
"Correct" export of `CustomerPortalConfig` is done in `customerPortalHandler.ts`

This caused the following warning: `WARN  Duplicated imports "CustomerPortalConfig"`