### PR TITLE
feat: restrict checkout to authenticated users

### DIFF
--- a/.changeset/vast-parents-do.md
+++ b/.changeset/vast-parents-do.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+restrict checkout to authenticated users

--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -49,6 +49,7 @@ const auth = betterAuth({
             // Configure checkout
             checkout: {
                 enabled: true,
+                onlyAuthenticated: false, // Restrict checkout to authenticated users
                 products: [
                     {
                         productId: "123-456-789", // ID of Product from Polar Dashboard
@@ -79,6 +80,7 @@ const auth = betterAuth({
 - `getCustomerCreateParams`: Custom function to provide additional customer creation parameters
 - `enableCustomerPortal`: Enable the customer portal functionality. Deployed as GET endpoint at /portal
 - `checkout.enabled`: Enable checkout functionality. Deployed as GET endpoint at /checkout
+- `checkout.onlyAuthenticated`: Restrict checkout to authenticated users
 - `checkout.products`: Array of products or function returning products. Slug passed will then be passable as route param.
 - `checkout.successUrl`: URL to redirect to after successful checkout
 

--- a/packages/polar-betterauth/package.json
+++ b/packages/polar-betterauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@polar-sh/better-auth",
-	"version": "0.0.10",
+	"version": "0.0.9",
 	"description": "Polar integration for better-auth",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/packages/polar-betterauth/package.json
+++ b/packages/polar-betterauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@polar-sh/better-auth",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Polar integration for better-auth",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",
@@ -25,15 +25,8 @@
 		"dev": "tsc --watch",
 		"check": "biome check --write ./src"
 	},
-	"files": [
-		"dist"
-	],
-	"keywords": [
-		"polar",
-		"better-auth",
-		"payments",
-		"subscriptions"
-	],
+	"files": ["dist"],
+	"keywords": ["polar", "better-auth", "payments", "subscriptions"],
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@polar-sh/sdk": "^0.32.0",

--- a/packages/polar-betterauth/src/endpoints/checkout.ts
+++ b/packages/polar-betterauth/src/endpoints/checkout.ts
@@ -29,6 +29,12 @@ export const checkout = (options: PolarOptions) =>
 
 			const session = await getSessionFromCtx(ctx);
 
+			if (options.checkout?.onlyAuthenticated && !session?.user.id) {
+				throw new APIError("UNAUTHORIZED", {
+					message: "User not authenticated",
+				});
+			}
+
 			try {
 				const checkout = await options.client.checkouts.create({
 					customerExternalId: session?.user.id,
@@ -84,6 +90,12 @@ export const checkoutWithSlug = (options: PolarOptions) =>
 			}
 
 			const session = await getSessionFromCtx(ctx);
+
+			if (options.checkout?.onlyAuthenticated && !session?.user.id) {
+				throw new APIError("UNAUTHORIZED", {
+					message: "User not authenticated",
+				});
+			}
 
 			try {
 				const checkout = await options.client.checkouts.create({

--- a/packages/polar-betterauth/src/types.ts
+++ b/packages/polar-betterauth/src/types.ts
@@ -74,6 +74,12 @@ export interface PolarOptions {
 		 */
 		enabled: boolean;
 		/**
+		 * Restrict checkout to authenticated users
+		 *
+		 * @default false
+		 */
+		onlyAuthenticated?: boolean;
+		/**
 		 * List of products
 		 */
 		products: Product[] | (() => Promise<Product[]>);


### PR DESCRIPTION
This patch adds an option to the Better Auth integration to prevent checkout sessions from being created if a user is not authenticated.