### PR TITLE
Removed file type identifier from sdk/webhooks import

### DIFF
--- a/packages/polar-betterauth/src/endpoints/webhooks.ts
+++ b/packages/polar-betterauth/src/endpoints/webhooks.ts
@@ -1,4 +1,4 @@
-import { validateEvent } from "@polar-sh/sdk/webhooks.js";
+import { validateEvent } from "@polar-sh/sdk/webhooks";
 import { APIError } from "better-auth/api";
 import { createAuthEndpoint } from "better-auth/plugins";
 import type { PolarOptions } from "../types";


### PR DESCRIPTION
This fixes a bug with the Sveltekit Vercel adapter in which during the build, Vite/Node cant resolve to the file, 

The module didnt have any tests, but it built so i assume everything is okay