### PR TITLE
fix: update products schema validation to correctly accept comma-separated strings

### DIFF
--- a/packages/polar-nuxt/src/runtime/server/checkoutHandler.ts
+++ b/packages/polar-nuxt/src/runtime/server/checkoutHandler.ts
@@ -10,7 +10,9 @@ export interface CheckoutConfig {
 }
 
 const checkoutQuerySchema = z.object({
-	products: z.array(z.string().nonempty()),
+	products: z.string()
+     .transform((value) => value.split(","))
+     .pipe( z.string().array() ),
 	customerId: z.string().nonempty().optional(),
 	customerExternalId: z.string().nonempty().optional(),
 	customerEmail: z.string().email().optional(),


### PR DESCRIPTION
Otherwise it caused error `[ { "code": "invalid_type", "expected": "array", "received": "string", "path": [ "products" ], "message": "Expected array, received string" } ]` if `/checkout?products=PRODUCT_ID` was passed to checkout hander