### PR TITLE
fix: update subscriptions example on better-auth adapter

### DIFF
--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -291,7 +291,7 @@ const { data: orders } = await authClient.customer.orders.list({
 This method lists the subscriptions associated with authenticated user/customer.
 
 ```typescript
-const { data: subscriptions } = await authClient.customer.orders.list({
+const { data: subscriptions } = await authClient.customer.subscriptions.list({
   query: {
     page: 1,
     limit: 10,


### PR DESCRIPTION
This pull request includes a minor correction in the `packages/polar-betterauth/README.md` file to fix an incorrect method call in the example code.

In the subscriptions section, updated the example code to use `authClient.customer.subscriptions.list` instead of `authClient.customer.orders.list` to correctly reflect the method for listing subscriptions.