### PR TITLE
Fix/update referenceid documentation in betterauth adapter

### DIFF
--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -313,11 +313,11 @@ So in order to figure out if a user should have access, pass the user's organiza
 ```typescript
 const organizationId = (await authClient.organization.list())?.data?.[0]?.id,
 
-const { data: subscriptions } = await authClient.customer.orders.list({
+const { data: subscriptions } = await authClient.customer.subscriptions.list({
     query: {
-	    page: 1,
-		limit: 10,
-		active: true,
+     page: 1,
+  limit: 10,
+  active: true,
         referenceId: organizationId
     },
 });

--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -315,9 +315,9 @@ const organizationId = (await authClient.organization.list())?.data?.[0]?.id,
 
 const { data: subscriptions } = await authClient.customer.subscriptions.list({
     query: {
-     page: 1,
-  limit: 10,
-  active: true,
+	    page: 1,
+		limit: 10,
+		active: true,
         referenceId: organizationId
     },
 });


### PR DESCRIPTION
The documentation is not reflecting the correct utilisation of the `referenceId` attribute. `referenceId` is not a valid options when building a query when fetching the orders, but it is when fetching subscriptions so I assume that this is a small typo.