### PR TITLE
Skip user creation when customer has conflict externalID

### DIFF
--- a/packages/polar-betterauth/src/hooks/customer.ts
+++ b/packages/polar-betterauth/src/hooks/customer.ts
@@ -74,3 +74,19 @@ export const onUserUpdate =
 			}
 		}
 	};
+
+export const beforeUserCreate =
+	(options: PolarOptions) =>
+	async (user: User, ctx?: GenericEndpointContext) => {
+		if (ctx && options.skipUserOnExternalIDConflict) {
+			const { result: existingCustomers } = await options.client.customers.list(
+				{ email: user.email },
+			);
+			const existingCustomer = existingCustomers.items[0];
+			if (existingCustomer && existingCustomer.externalId !== user.id) {
+				throw new APIError("CONFLICT", {
+					message: `Customer with email ${user.email} already exists with a different external ID.`,
+				});
+			}
+		}
+	};

--- a/packages/polar-betterauth/src/index.ts
+++ b/packages/polar-betterauth/src/index.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthPlugin } from "better-auth";
-import { onUserCreate, onUserUpdate } from "./hooks/customer";
+import { beforeUserCreate, onUserCreate, onUserUpdate } from "./hooks/customer";
 import type { PolarEndpoints, PolarOptions } from "./types";
 
 export { polarClient } from "./client";
@@ -28,6 +28,7 @@ export const polar = <O extends PolarOptions>(options: O) => {
 					databaseHooks: {
 						user: {
 							create: {
+								before: beforeUserCreate(options),
 								after: onUserCreate(options),
 							},
 							update: {

--- a/packages/polar-betterauth/src/types.ts
+++ b/packages/polar-betterauth/src/types.ts
@@ -32,10 +32,12 @@ export interface PolarOptions {
 	 * Polar Client
 	 */
 	client: Polar;
+
 	/**
 	 * Enable customer creation when a user signs up
 	 */
 	createCustomerOnSignUp?: boolean;
+
 	/**
 	 * A custom function to get the customer create
 	 * params
@@ -50,6 +52,12 @@ export interface PolarOptions {
 	) => Promise<{
 		metadata?: Record<string, string>;
 	}>;
+
+	/**
+	 * Do not create a new user if polar customer exists with different externalId
+	 */
+	skipUserOnExternalIDConflict?: boolean;
+
 	/**
 	 * Use Polar plugins
 	 */


### PR DESCRIPTION
At the moment, when we enable `createCustomerOnSignUp` , it could happen that when an user signs up with an email that duplicates with an existing customer in Polar, Polar will throw an error in the sign up screen, however, user is still created in the database.

This PR add an option to tell `better-auth` to skip creating new user record when that happens.