### PR TITLE
fix: add deno to changeset

### DIFF
--- a/.changeset/quiet-cloths-fail.md
+++ b/.changeset/quiet-cloths-fail.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/deno": minor
+---
+
+fix: add deno to changeset

--- a/packages/polar-deno/CHANGELOG.md
+++ b/packages/polar-deno/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @polar-sh/deno
+
+## 0.1.1
+
+### Patch Changes
+
+- First release of the Deno adapter.

--- a/packages/polar-deno/package.json
+++ b/packages/polar-deno/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@polar-sh/deno",
+  "version": "0.1.1",
+  "private": true
+}


### PR DESCRIPTION
# Context
Deno is not in the automatic release process and wasn't updated in a long time.
Seems that changeset needs a [package.json](https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md) file to manage the apps.