### PR TITLE
fix: fallback to baseURL when creating checkout URL on server

### DIFF
--- a/.changeset/fresh-plants-sneeze.md
+++ b/.changeset/fresh-plants-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Fallback to the better-auth defined baseURL for checkouts created on the server

--- a/.changeset/fresh-plants-sneeze.md
+++ b/.changeset/fresh-plants-sneeze.md
@@ -2,4 +2,4 @@
 "@polar-sh/better-auth": patch
 ---
 
-Fallback to the better-auth defined baseURL for checkouts created on the server
+Fall back to base URL when creating a checkout on the server outside of a request context.

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -100,7 +100,7 @@ export const checkout =
 							successUrl: checkoutOptions.successUrl
 								? new URL(
 										checkoutOptions.successUrl,
-										ctx.request?.url,
+                    ctx.request?.url ?? ctx.context.baseURL
 									).toString()
 								: undefined,
 							metadata: ctx.body.referenceId

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -100,7 +100,7 @@ export const checkout =
 							successUrl: checkoutOptions.successUrl
 								? new URL(
 										checkoutOptions.successUrl,
-                    ctx.request?.url ?? ctx.context.baseURL
+										ctx.request?.url ?? ctx.context.baseURL,
 									).toString()
 								: undefined,
 							metadata: ctx.body.referenceId


### PR DESCRIPTION
- Resolves #266 
- Fallback to the baseURL that is defined in the users better-auth config.