### PR TITLE
add redirect and successQueryParams options

### DIFF
--- a/packages/polar-betterauth/package.json
+++ b/packages/polar-betterauth/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@polar-sh/better-auth",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Polar integration for better-auth",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.js",

--- a/packages/polar-betterauth/src/plugins/portal.ts
+++ b/packages/polar-betterauth/src/plugins/portal.ts
@@ -11,6 +11,9 @@ export const portal = () => (polar: Polar) => {
 			{
 				method: "GET",
 				use: [sessionMiddleware],
+				query: z.object({ 
+          redirect: z.coerce.boolean().optional().default(true) 
+        }),
 			},
 			async (ctx) => {
 				if (!ctx.context.session?.user.id) {
@@ -26,7 +29,7 @@ export const portal = () => (polar: Polar) => {
 
 					return ctx.json({
 						url: customerSession.customerPortalUrl,
-						redirect: true,
+						redirect: ctx.query?.redirect ?? true,
 					});
 				} catch (e: unknown) {
 					if (e instanceof Error) {


### PR DESCRIPTION
This change introduces 2 new properties to the Better-Auth Polar Plugin, specifically on the client side.

### Checkout Body

_**redirect: boolean**_
Allows the authClient.checkout() function to return the url in its data without automatically redirecting

_**successQueryParams: record<String, String>**_
Allows the authClient.checkout() to take in arguments that will then be passed to the successUrl as query params

### Portal Query
_**redirect: boolean**_
Allows the authClient.customer.portal() function to return the url in its data without automatically redirecting
<br>
This gives devs more freedom to open the checkout & portal windows where they would like, and pass more context to the successUrl.