### PR TITLE
populate email and name in betterauth checkout

### DIFF
--- a/.changeset/sad-walls-sniff.md
+++ b/.changeset/sad-walls-sniff.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Pre-populate email and name fields in better-auth checkout plugin based on the session data.

--- a/packages/polar-betterauth/src/__tests__/plugins/checkout.test.ts
+++ b/packages/polar-betterauth/src/__tests__/plugins/checkout.test.ts
@@ -94,7 +94,7 @@ describe("checkout plugin", () => {
 		it("should create checkout with product IDs", async () => {
 			const mockCheckout = createMockCheckout();
 			vi.mocked(getSessionFromCtx).mockResolvedValue({
-				user: { id: "user-123" },
+				user: { id: "user-123", email: "user@example.com", name: "Test User" },
 			});
 			vi.mocked(mockClient.checkouts.create).mockResolvedValue(mockCheckout);
 
@@ -108,13 +108,17 @@ describe("checkout plugin", () => {
 
 			await handler(ctx);
 
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: "user-123",
-				products: ["prod-123", "prod-456"],
-				successUrl: "https://example.com/success",
-				metadata: undefined,
-				customFieldData: undefined,
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: "user-123",
+					products: ["prod-123", "prod-456"],
+					successUrl: "https://example.com/success",
+					metadata: undefined,
+					customFieldData: undefined,
+					customerEmail: "user@example.com",
+					customerName: "Test User",
+				}),
+			);
 
 			expect(ctx.json).toHaveBeenCalledWith({
 				url: expect.stringContaining("theme=dark"),
@@ -139,13 +143,15 @@ describe("checkout plugin", () => {
 
 			await handler(ctx);
 
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: "user-123",
-				products: ["prod-123"],
-				successUrl: "https://example.com/success",
-				metadata: undefined,
-				customFieldData: undefined,
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: "user-123",
+					products: ["prod-123"],
+					successUrl: "https://example.com/success",
+					metadata: undefined,
+					customFieldData: undefined,
+				}),
+			);
 		});
 
 		it("should create checkout with product slug", async () => {
@@ -165,13 +171,17 @@ describe("checkout plugin", () => {
 
 			await handler(ctx);
 
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: "user-123",
-				products: ["prod-123"],
-				successUrl: "https://example.com/success",
-				metadata: undefined,
-				customFieldData: undefined,
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: "user-123",
+					products: ["prod-123"],
+					successUrl: "https://example.com/success",
+					metadata: undefined,
+					customFieldData: undefined,
+					customerEmail: undefined,
+					customerName: undefined,
+				}),
+			);
 		});
 
 		it("should handle async product resolution", async () => {
@@ -202,13 +212,17 @@ describe("checkout plugin", () => {
 			await asyncHandler(ctx);
 
 			expect(asyncProducts).toHaveBeenCalled();
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: "user-123",
-				products: ["async-prod-123"],
-				successUrl: undefined,
-				metadata: undefined,
-				customFieldData: undefined,
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: "user-123",
+					products: ["async-prod-123"],
+					successUrl: undefined,
+					metadata: undefined,
+					customFieldData: undefined,
+					customerEmail: undefined,
+					customerName: undefined,
+				}),
+			);
 		});
 
 		it("should throw error for unknown product slug", async () => {
@@ -246,13 +260,17 @@ describe("checkout plugin", () => {
 
 			await handler(ctx);
 
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: "user-123",
-				products: ["prod-123"],
-				successUrl: "https://example.com/success",
-				metadata: { referenceId: "ref-123", key: "value" },
-				customFieldData: { field: "data" },
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: "user-123",
+					products: ["prod-123"],
+					successUrl: "https://example.com/success",
+					metadata: { referenceId: "ref-123", key: "value" },
+					customFieldData: { field: "data" },
+					customerEmail: undefined,
+					customerName: undefined,
+				}),
+			);
 		});
 
 		it("should handle unauthenticated users when not required", async () => {
@@ -274,13 +292,17 @@ describe("checkout plugin", () => {
 
 			await publicHandler(ctx);
 
-			expect(mockClient.checkouts.create).toHaveBeenCalledWith({
-				externalCustomerId: undefined,
-				products: ["prod-123"],
-				successUrl: undefined,
-				metadata: undefined,
-				customFieldData: undefined,
-			});
+			expect(mockClient.checkouts.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					externalCustomerId: undefined,
+					products: ["prod-123"],
+					successUrl: undefined,
+					metadata: undefined,
+					customFieldData: undefined,
+					customerEmail: undefined,
+					customerName: undefined,
+				}),
+			);
 		});
 
 		it("should throw error for unauthenticated users when authentication required", async () => {

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -103,6 +103,8 @@ export const checkout =
 										ctx.request?.url,
 									).toString()
 								: undefined,
+							customerEmail: session?.user.email,
+							customerName: session?.user.name,
 							metadata: ctx.body.referenceId
 								? {
 										referenceId: ctx.body.referenceId,
@@ -111,7 +113,7 @@ export const checkout =
 								: ctx.body.metadata,
 							customFieldData: ctx.body.customFieldData,
 							allowDiscountCodes: ctx.body.allowDiscountCodes ?? true,
-							discountId: ctx.body.discountId
+							discountId: ctx.body.discountId,
 						});
 
 						const redirectUrl = new URL(checkout.url);


### PR DESCRIPTION
Resolves #279 

I modified how the checkout is created to set the `customerEmail` and `customerName` fields to bet set based on the session. For unauthenticated requests the checkout is created with both of these set to `undefined`.

I modified the checkout tests to account for this change.