### PR TITLE
Add extra options to better-auth client functions

### DIFF
--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -45,6 +45,7 @@ export const CheckoutParams = z.object({
 	discountId: z.string().optional(),
 	redirect: z.coerce.boolean().optional(),
 	embedOrigin: z.string().url().optional(),
+	successQueryParams: z.record(z.string(), z.string()).optional(),
 });
 
 export type CheckoutParams = z.infer<typeof CheckoutParams>;
@@ -98,10 +99,19 @@ export const checkout =
 							externalCustomerId: session?.user.id,
 							products: productIds,
 							successUrl: checkoutOptions.successUrl
-								? new URL(
+								? (() => {
+									const url = new URL(
 										checkoutOptions.successUrl,
 										ctx.request?.url ?? ctx.context.baseURL,
-									).toString()
+									)
+
+									if (ctx.body.successQueryParams) {
+										for (const [key, value] of Object.entries(ctx.body.successQueryParams)) {
+											url.searchParams.set(key, value);
+										}
+									}
+									return url.toString();
+								})()
 								: undefined,
 							metadata: ctx.body.referenceId
 								? {

--- a/packages/polar-betterauth/src/plugins/portal.ts
+++ b/packages/polar-betterauth/src/plugins/portal.ts
@@ -8,6 +8,10 @@ export interface PortalConfig {
 	returnUrl?: string;
 }
 
+export const PortalParams = z.object({
+	redirect: z.coerce.boolean().optional(),
+}).optional();
+
 export const portal =
 	({ returnUrl }: PortalConfig = {}) =>
 	(polar: Polar) => {
@@ -19,6 +23,7 @@ export const portal =
 				{
 					method: "GET",
 					use: [sessionMiddleware],
+					query: PortalParams,
 				},
 				async (ctx) => {
 					if (!ctx.context.session?.user.id) {
@@ -35,7 +40,7 @@ export const portal =
 
 						return ctx.json({
 							url: customerSession.customerPortalUrl,
-							redirect: true,
+							redirect: ctx.query?.redirect ?? true,
 						});
 					} catch (e: unknown) {
 						if (e instanceof Error) {


### PR DESCRIPTION
1. Allows optional query params to be passed from the frontend with its success URL. This is useful for users with multiple clients using the same polar instance, ex. Web + Mobile. The extra data is passed to the successURL as a queryParam, where the developer can then redirect the users to the proper application.

2. Add redirect to portal options. Checkout already allows redirect to be specified on the frontend. With this change the portal can also specify this option and receive the link through authClient.portal()