### PR TITLE
Skip creating customers for anonymous users

### DIFF
--- a/.changeset/fiery-hotels-smell.md
+++ b/.changeset/fiery-hotels-smell.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Skip creating customers for anonymous users

--- a/packages/polar-betterauth/src/hooks/customer.ts
+++ b/packages/polar-betterauth/src/hooks/customer.ts
@@ -7,6 +7,10 @@ export const onBeforeUserCreate =
 	async (user: Partial<User>, context: GenericEndpointContext | null) => {
 		if (context && options.createCustomerOnSignUp) {
 			try {
+				if (user.isAnonymous) {
+					return;
+				}
+
 				const params = options.getCustomerCreateParams
 					? await options.getCustomerCreateParams({
 							user,
@@ -50,6 +54,10 @@ export const onAfterUserCreate =
 	(options: PolarOptions) =>
 	async (user: User, context: GenericEndpointContext | null) => {
 		if (context && options.createCustomerOnSignUp) {
+			if (user.isAnonymous) {
+				return;
+			}
+
 			try {
 				const { result: existingCustomers } =
 					await options.client.customers.list({ email: user.email });
@@ -84,6 +92,10 @@ export const onUserUpdate =
 	async (user: User, context: GenericEndpointContext | null) => {
 		if (context && options.createCustomerOnSignUp) {
 			try {
+				if (user.isAnonymous) {
+					return;
+				}
+
 				await options.client.customers.updateExternal({
 					externalId: user.id,
 					customerUpdateExternalID: {
@@ -110,6 +122,10 @@ export const onUserDelete =
 	async (user: User, context: GenericEndpointContext | null) => {
 		if (context && options.createCustomerOnSignUp) {
 			try {
+				if (user.isAnonymous) {
+					return;
+				}
+
 				if (user.email) {
 					const { result: existingCustomers } =
 						await options.client.customers.list({ email: user.email });


### PR DESCRIPTION
Resolves https://github.com/polarsource/polar/issues/7886.

Know that when you have [account linking](https://www.better-auth.com/docs/plugins/anonymous#link-account) enabled, this won't play nicely with our current architecture for event tracking and usage tracking, since your linked user will get a new user ID (and external customer ID's are immutable), so if you have tracked usage for the anonymous user using its `user.id` as the event's `external_customer_id`, this will break. We currently don't have a way to merge or update these distinct ID's.

TLDR: when authenticating an anonymous user, this will be considered a _new_ user both from Better Auth (and thus from Polar) perspective.