### PR TITLE
Ensure anonymous users don't reach checkout or customer portal

### DIFF
--- a/.changeset/sour-colts-wash.md
+++ b/.changeset/sour-colts-wash.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Fix `checkout` & `portal` integration for anonymous users

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -108,10 +108,18 @@ export const checkout =
 							: [ctx.body.products].filter((id) => id !== undefined);
 					}
 
-					if (checkoutOptions.authenticatedUsersOnly && !session?.user.id) {
-						throw new APIError("UNAUTHORIZED", {
-							message: "You must be logged in to checkout",
-						});
+					if (checkoutOptions.authenticatedUsersOnly) {
+						if (!session?.user.id) {
+							throw new APIError("UNAUTHORIZED", {
+								message: "You must be logged in to checkout",
+							});
+						}
+
+						if (session.user['isAnonymous']) {
+							throw new APIError("UNAUTHORIZED", {
+								message: "Anonymous users are not allowed to checkout",
+							});
+						}
 					}
 
 					const successUrl =

--- a/packages/polar-betterauth/src/plugins/portal.ts
+++ b/packages/polar-betterauth/src/plugins/portal.ts
@@ -27,6 +27,12 @@ export const portal =
 						});
 					}
 
+					if (ctx.context.session?.user['isAnonymous']) {
+						throw new APIError("UNAUTHORIZED", {
+							message: "Anonymous users cannot access the portal",
+						});
+					}
+
 					try {
 						const customerSession = await polar.customerSessions.create({
 							externalCustomerId: ctx.context.session?.user.id,


### PR DESCRIPTION
- No checkout for anonymous users if `authenticatedUsersOnly` is `true`
- No customer portal for anonymous users (since they can't exist as customers in Polar as there is no email)

There's an edge case where anonymous users can become Polar customers (when `authenticatedUsersOnly` is `false` and an anonymous user went through the checkout flow), but that'll be wonky (since you don't know whether or not they're a customer in Polar from your Better Auth codebase)