### PR TITLE
fix(polar-betterauth): fix zod versioning to stop client type inference issues

### DIFF
--- a/packages/polar-betterauth/package.json
+++ b/packages/polar-betterauth/package.json
@@ -56,12 +56,13 @@
     "@types/node": "^20.0.0",
     "better-auth": "^1.4.18",
     "tsup": "^8.5.1",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "peerDependencies": {
     "@polar-sh/sdk": "^0.46.6",
     "better-auth": "^1.4.12",
-    "zod": "^3.24.2 || ^4"
+    "zod": "^3.25.0 || ^4.0.0"
   },
   "dependencies": {
     "@polar-sh/checkout": "^0.2.0"

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -49,7 +49,7 @@ export const CheckoutParams = z.object({
 	allowDiscountCodes: z.coerce.boolean().optional(),
 	discountId: z.string().optional(),
 	redirect: z.coerce.boolean().optional(),
-	embedOrigin: z.string().url().optional(),
+	embedOrigin: z.url().optional(),
 	successUrl: z
 		.string()
 		.refine((val) => val.startsWith("/") || URL.canParse(val), {

--- a/packages/polar-betterauth/src/plugins/checkout.ts
+++ b/packages/polar-betterauth/src/plugins/checkout.ts
@@ -4,7 +4,7 @@ import {
 	createAuthEndpoint,
 	getSessionFromCtx,
 } from "better-auth/api";
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { Product } from "../types";
 
 export interface CheckoutOptions {

--- a/packages/polar-betterauth/src/plugins/portal.ts
+++ b/packages/polar-betterauth/src/plugins/portal.ts
@@ -1,7 +1,7 @@
 import type { Polar } from "@polar-sh/sdk";
 import { APIError } from "better-auth/api";
 import { createAuthEndpoint, sessionMiddleware } from "better-auth/api";
-import { z } from "zod";
+import * as z from "zod/v4";
 
 export interface PortalConfig {
 	returnUrl?: string;

--- a/packages/polar-betterauth/src/plugins/usage.ts
+++ b/packages/polar-betterauth/src/plugins/usage.ts
@@ -4,7 +4,7 @@ import {
 	createAuthEndpoint,
 	sessionMiddleware,
 } from "better-auth/api";
-import { z } from "zod";
+import * as z from "zod/v4";
 import type { Product } from "../types";
 
 export interface UsageOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,9 +116,6 @@ importers:
       '@polar-sh/checkout':
         specifier: ^0.2.0
         version: 0.2.0(@stripe/react-stripe-js@3.10.0(@stripe/stripe-js@7.9.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@stripe/stripe-js@7.9.0)(@types/react-dom@19.1.9(@types/react@19.1.16))(@types/react@19.1.16)(react-dom@19.1.1(react@19.1.1))(react-is@16.13.1)(react@19.1.1)(redux@5.0.1)
-      zod:
-        specifier: ^3.24.2 || ^4
-        version: 3.25.76
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -144,6 +141,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.13)(lightningcss@1.30.1)(terser@5.44.0)
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 3.25.76
 
   packages/polar-elysia:
     dependencies:


### PR DESCRIPTION
Currently, the better-auth plugin client types break when using zod v4 in the same project. 

This is seen in multiple issues.
https://github.com/polarsource/polar/issues/8754
https://github.com/polarsource/polar/issues/8573

This change aims to follow the practices outline by zod for supporting both version 3 and 4 as seen in the docs:
https://zod.dev/v4/versioning
https://zod.dev/library-authors

By setting the peer depedency to:  `"zod": "^3.25.0 || ^4.0.0"` and using the v4 package directly: `import * as z from "zod/v4";` we can avoid the issue where users are seeing certain polar better-auth plugins typed as `any`