### PR TITLE
fix(polar-betterauth): break circular dependency between client and index

### DIFF
--- a/.changeset/fix-betterauth-circular-dependency.md
+++ b/.changeset/fix-betterauth-circular-dependency.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Fix circular dependency between `client.ts` and `index.ts` that caused type inference issues for `$InferServerPlugin`

--- a/packages/polar-betterauth/src/client.ts
+++ b/packages/polar-betterauth/src/client.ts
@@ -2,7 +2,8 @@ import { PolarEmbedCheckout } from "@polar-sh/checkout/embed";
 import type { PolarEmbedCheckout as PolarEmbedCheckoutType } from "@polar-sh/checkout/embed";
 import type { BetterAuthClientPlugin } from "better-auth";
 import type { BetterFetchOption } from "better-auth/client";
-import type { CheckoutParams, polar } from "./index";
+import type { CheckoutParams } from "./plugins/checkout";
+import type { polar } from "./server";
 
 export type { PolarEmbedCheckoutType as PolarEmbedCheckout };
 

--- a/packages/polar-betterauth/src/index.ts
+++ b/packages/polar-betterauth/src/index.ts
@@ -1,51 +1,7 @@
-import type { BetterAuthPlugin } from "better-auth";
-import {
-	onAfterUserCreate,
-	onBeforeUserCreate,
-	onUserDelete,
-	onUserUpdate,
-} from "./hooks/customer";
-import type { PolarEndpoints, PolarOptions } from "./types";
-
 export { polarClient } from "./client";
+export { polar } from "./server";
 
 export * from "./plugins/portal";
 export * from "./plugins/checkout";
 export * from "./plugins/usage";
 export * from "./plugins/webhooks";
-
-export const polar = <O extends PolarOptions>(options: O) => {
-	const plugins = options.use
-		.map((use) => use(options.client))
-		.reduce((acc, plugin) => {
-			Object.assign(acc, plugin);
-			return acc;
-		}, {} as PolarEndpoints);
-
-	return {
-		id: "polar",
-		endpoints: {
-			...plugins,
-		},
-		init() {
-			return {
-				options: {
-					databaseHooks: {
-						user: {
-							create: {
-								before: onBeforeUserCreate(options),
-								after: onAfterUserCreate(options),
-							},
-							update: {
-								after: onUserUpdate(options),
-							},
-							delete: {
-								after: onUserDelete(options),
-							},
-						},
-					},
-				},
-			};
-		},
-	} satisfies BetterAuthPlugin;
-};

--- a/packages/polar-betterauth/src/server.ts
+++ b/packages/polar-betterauth/src/server.ts
@@ -1,0 +1,44 @@
+import type { BetterAuthPlugin } from "better-auth";
+import {
+	onAfterUserCreate,
+	onBeforeUserCreate,
+	onUserDelete,
+	onUserUpdate,
+} from "./hooks/customer";
+import type { PolarEndpoints, PolarOptions } from "./types";
+
+export const polar = <O extends PolarOptions>(options: O) => {
+	const plugins = options.use
+		.map((use) => use(options.client))
+		.reduce((acc, plugin) => {
+			Object.assign(acc, plugin);
+			return acc;
+		}, {} as PolarEndpoints);
+
+	return {
+		id: "polar",
+		endpoints: {
+			...plugins,
+		},
+		init() {
+			return {
+				options: {
+					databaseHooks: {
+						user: {
+							create: {
+								before: onBeforeUserCreate(options),
+								after: onAfterUserCreate(options),
+							},
+							update: {
+								after: onUserUpdate(options),
+							},
+							delete: {
+								after: onUserDelete(options),
+							},
+						},
+					},
+				},
+			};
+		},
+	} satisfies BetterAuthPlugin;
+};


### PR DESCRIPTION
Extract `polar` server plugin into server.ts so client.ts can import it directly without going through index.ts, which re-exports polarClient from client.ts, forming a cycle that prevented type inference.