### PR TITLE
fix(@polar-sh/astro): Allow peer with Astro 6

### DIFF
--- a/.changeset/wide-rules-flow.md
+++ b/.changeset/wide-rules-flow.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/astro": patch
+---
+
+Allow installing with Astro 6.

--- a/packages/polar-astro/package.json
+++ b/packages/polar-astro/package.json
@@ -35,12 +35,13 @@
     "subscriptions"
   ],
   "peerDependencies": {
-    "astro": "^5.0.0"
+    "astro": "^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@sindresorhus/tsconfig": "^7.0.0",
     "@types/node": "^20.0.0",
+    "astro": "^5.0.0 || ^6.0.0",
     "prettier": "^3.7.4",
     "tsup": "^8.5.1",
     "vitest": "^2.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ importers:
       '@polar-sh/sdk':
         specifier: ^0.47.0
         version: 0.47.0
-      astro:
-        specifier: ^5.0.0
-        version: 5.13.6(@types/node@20.19.13)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(rollup@4.50.2)(terser@5.44.0)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.1)
     devDependencies:
       '@biomejs/biome':
         specifier: 1.9.4
@@ -101,6 +98,9 @@ importers:
       '@types/node':
         specifier: ^20.0.0
         version: 20.19.13
+      astro:
+        specifier: ^5.0.0 || ^6.0.0
+        version: 5.13.6(@types/node@20.19.13)(db0@0.3.2(better-sqlite3@11.10.0))(ioredis@5.7.0)(jiti@2.6.1)(lightningcss@1.30.1)(rollup@4.50.2)(terser@5.44.0)(tsx@4.20.5)(typescript@5.9.3)(yaml@2.8.1)
       prettier:
         specifier: ^3.7.4
         version: 3.7.4


### PR DESCRIPTION
Fixes https://github.com/polarsource/polar/issues/10477

Added Astro v6 as a peer dependency and Astro as a dev dependency. Compatibility is straightforward, as the only Astro API used here is `getSecret`, which has no breaking changes between Astro v5 and v6.