### PR TITLE
fix(better-auth): preserve webhook handler error statuses

### DIFF
--- a/.changeset/better-auth-webhook-errors.md
+++ b/.changeset/better-auth-webhook-errors.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": patch
+---
+
+Preserve explicit APIError statuses thrown by webhook handlers and report unexpected handler failures as internal server errors.

--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -465,6 +465,25 @@ Add the secret to your environment.
 POLAR_WEBHOOK_SECRET=...
 ```
 
+Webhook handlers should throw when event processing fails. Unexpected handler
+errors return an internal server error response. To choose a specific non-2xx
+status, throw Better Auth's `APIError` from the handler.
+
+```typescript
+import { APIError } from "better-auth/api";
+
+webhooks({
+  secret: process.env.POLAR_WEBHOOK_SECRET,
+  onOrderPaid: async (payload) => {
+    if (!canProcessOrder(payload.data.id)) {
+      throw new APIError("FORBIDDEN", {
+        message: "Order cannot be processed",
+      });
+    }
+  },
+});
+```
+
 The plugin supports handlers for all Polar webhook events:
 
 - `onPayload` - Catch-all handler for any incoming Webhook event

--- a/packages/polar-betterauth/src/__tests__/plugins/webhooks.test.ts
+++ b/packages/polar-betterauth/src/__tests__/plugins/webhooks.test.ts
@@ -242,9 +242,10 @@ describe("webhooks plugin", () => {
 				context: { logger: { error: vi.fn() } },
 			};
 
-			await expect(handler(ctx)).rejects.toThrow(
-				"Webhook error: See server logs for more information.",
-			);
+			await expect(handler(ctx)).rejects.toMatchObject({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Webhook error: See server logs for more information.",
+			});
 			expect(ctx.context.logger.error).toHaveBeenCalledWith(
 				"Polar webhook failed. Error: Handler processing failed",
 			);
@@ -260,11 +261,31 @@ describe("webhooks plugin", () => {
 				context: { logger: { error: vi.fn() } },
 			};
 
-			await expect(handler(ctx)).rejects.toThrow(
-				"Webhook error: See server logs for more information.",
-			);
+			await expect(handler(ctx)).rejects.toMatchObject({
+				code: "INTERNAL_SERVER_ERROR",
+				message: "Webhook error: See server logs for more information.",
+			});
 			expect(ctx.context.logger.error).toHaveBeenCalledWith(
 				"Polar webhook failed. Error: Unknown error",
+			);
+		});
+
+		it("should preserve explicit APIError status from webhook handlers", async () => {
+			const mockEvent = { type: "checkout.created", data: {} };
+			const apiError = new APIError("FORBIDDEN", {
+				message: "Webhook handler rejected the event",
+			});
+			vi.mocked(validateEvent).mockReturnValue(mockEvent);
+			vi.mocked(handleWebhookPayload).mockRejectedValue(apiError);
+
+			const ctx = {
+				request: mockRequest,
+				context: { logger: { error: vi.fn() } },
+			};
+
+			await expect(handler(ctx)).rejects.toBe(apiError);
+			expect(ctx.context.logger.error).toHaveBeenCalledWith(
+				"Polar webhook failed. Error: Webhook handler rejected the event",
 			);
 		});
 

--- a/packages/polar-betterauth/src/plugins/webhooks.ts
+++ b/packages/polar-betterauth/src/plugins/webhooks.ts
@@ -221,6 +221,13 @@ export const webhooks = (options: WebhooksOptions) => (_polar: Polar) => {
 						...eventHandlers,
 					});
 				} catch (e: unknown) {
+					if (e instanceof APIError) {
+						ctx.context.logger.error(
+							`Polar webhook failed. Error: ${e.message}`,
+						);
+						throw e;
+					}
+
 					if (e instanceof Error) {
 						ctx.context.logger.error(
 							`Polar webhook failed. Error: ${e.message}`,
@@ -229,7 +236,7 @@ export const webhooks = (options: WebhooksOptions) => (_polar: Polar) => {
 						ctx.context.logger.error(`Polar webhook failed. Error: ${e}`);
 					}
 
-					throw new APIError("BAD_REQUEST", {
+					throw new APIError("INTERNAL_SERVER_ERROR", {
 						message: "Webhook error: See server logs for more information.",
 					});
 				}


### PR DESCRIPTION
## Summary
- preserve explicit Better Auth `APIError` statuses thrown by Polar webhook handlers
- return `INTERNAL_SERVER_ERROR` for unexpected handler failures instead of treating processing errors as bad requests
- document how webhook handlers can intentionally return non-2xx responses
- add focused Better Auth webhook tests and a patch changeset

Fixes #173.

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter @polar-sh/adapter-utils build`
- `pnpm exec vitest run src/__tests__/plugins/webhooks.test.ts` from `packages/polar-betterauth` - 15 tests passed
- `pnpm --filter @polar-sh/better-auth build`
- `pnpm exec vitest run` from `packages/polar-betterauth` - 7 files, 100 tests passed
- `pnpm --filter @polar-sh/better-auth check`

## Notes
- `pnpm install` reported ignored build scripts for some dependencies, but install completed and the relevant build/test/check commands passed.
- Running package-local `pnpm exec` emitted `.npmrc` warnings for missing `${NPM_TOKEN}`; tests still completed successfully.