### PR TITLE
better-auth: Add `anonymizeCustomerOnDelete` option for GDPR compliance

### DIFF
--- a/.changeset/feat-betterauth-anonymize-customer-on-delete.md
+++ b/.changeset/feat-betterauth-anonymize-customer-on-delete.md
@@ -1,0 +1,5 @@
+---
+"@polar-sh/better-auth": minor
+---
+
+Add an `anonymizeCustomerOnDelete` option to also anonymize the Polar customer's personal data for GDPR compliance when the customer is deleted on user deletion

--- a/packages/polar-betterauth/README.md
+++ b/packages/polar-betterauth/README.md
@@ -147,6 +147,7 @@ const auth = betterAuth({
 
 - `createCustomerOnSignUp`: Automatically create a Polar customer when a user signs up
 - `getCustomerCreateParams`: Custom function to provide additional customer creation metadata
+- `anonymizeCustomerOnDelete`: Also anonymize the Polar customer's personal data (hashed email and name, cleared billing address, removed OAuth data) for GDPR compliance when the customer is deleted on user deletion
 
 ### Customers
 

--- a/packages/polar-betterauth/src/__tests__/hooks/customer.test.ts
+++ b/packages/polar-betterauth/src/__tests__/hooks/customer.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	onAfterUserCreate,
 	onBeforeUserCreate,
+	onUserDelete,
 	onUserUpdate,
 } from "../../hooks/customer";
 import { createTestPolarOptions, mockApiError } from "../utils/helpers";
@@ -558,6 +559,167 @@ describe("customer hooks", () => {
 
 			expect(ctx.context.logger.error).toHaveBeenCalledWith(
 				"Polar customer update failed. Error: Network timeout",
+			);
+		});
+	});
+
+	describe("onUserDelete", () => {
+		it("should anonymize the customer when anonymizeCustomerOnDelete is enabled", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: true,
+				anonymizeCustomerOnDelete: true,
+			});
+
+			const mockUser = createMockUser({
+				id: "user-123",
+				email: "test@example.com",
+			});
+
+			const existingCustomer = {
+				...createMockCustomer(),
+				id: "customer-456",
+			};
+
+			vi.mocked(mockClient.customers.list).mockResolvedValue({
+				result: {
+					items: [existingCustomer],
+					pagination: { totalCount: 1, maxPage: 1 },
+				},
+				next: vi.fn(),
+				[Symbol.asyncIterator]: vi.fn(),
+			});
+
+			const ctx = { context: { logger: { error: vi.fn() } } } as any;
+			const hook = onUserDelete(options);
+
+			await hook(mockUser, ctx);
+
+			expect(mockClient.customers.delete).toHaveBeenCalledWith({
+				id: "customer-456",
+				anonymize: true,
+			});
+		});
+
+		it("should default anonymize to false when the option is not set", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: true,
+			});
+
+			const mockUser = createMockUser({
+				id: "user-123",
+				email: "test@example.com",
+			});
+
+			const existingCustomer = {
+				...createMockCustomer(),
+				id: "customer-456",
+			};
+
+			vi.mocked(mockClient.customers.list).mockResolvedValue({
+				result: {
+					items: [existingCustomer],
+					pagination: { totalCount: 1, maxPage: 1 },
+				},
+				next: vi.fn(),
+				[Symbol.asyncIterator]: vi.fn(),
+			});
+
+			const ctx = { context: { logger: { error: vi.fn() } } } as any;
+			const hook = onUserDelete(options);
+
+			await hook(mockUser, ctx);
+
+			expect(mockClient.customers.delete).toHaveBeenCalledWith({
+				id: "customer-456",
+				anonymize: false,
+			});
+		});
+
+		it("should not delete when no matching customer exists", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: true,
+				anonymizeCustomerOnDelete: true,
+			});
+
+			const mockUser = createMockUser({ email: "test@example.com" });
+			const ctx = { context: { logger: { error: vi.fn() } } } as any;
+			const hook = onUserDelete(options);
+
+			await hook(mockUser, ctx);
+
+			expect(mockClient.customers.delete).not.toHaveBeenCalled();
+		});
+
+		it("should not delete when createCustomerOnSignUp is disabled", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: false,
+			});
+
+			const mockUser = createMockUser();
+			const ctx = { context: { logger: { error: vi.fn() } } } as any;
+			const hook = onUserDelete(options);
+
+			await hook(mockUser, ctx);
+
+			expect(mockClient.customers.list).not.toHaveBeenCalled();
+			expect(mockClient.customers.delete).not.toHaveBeenCalled();
+		});
+
+		it("should not delete when context is missing", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: true,
+				anonymizeCustomerOnDelete: true,
+			});
+
+			const mockUser = createMockUser();
+			const hook = onUserDelete(options);
+
+			await hook(mockUser); // No context provided
+
+			expect(mockClient.customers.list).not.toHaveBeenCalled();
+			expect(mockClient.customers.delete).not.toHaveBeenCalled();
+		});
+
+		it("should log and swallow errors during customer deletion", async () => {
+			const options = createTestPolarOptions({
+				client: mockClient,
+				createCustomerOnSignUp: true,
+				anonymizeCustomerOnDelete: true,
+			});
+
+			const mockUser = createMockUser({ email: "test@example.com" });
+
+			const existingCustomer = {
+				...createMockCustomer(),
+				id: "customer-456",
+			};
+
+			vi.mocked(mockClient.customers.list).mockResolvedValue({
+				result: {
+					items: [existingCustomer],
+					pagination: { totalCount: 1, maxPage: 1 },
+				},
+				next: vi.fn(),
+				[Symbol.asyncIterator]: vi.fn(),
+			});
+
+			vi.mocked(mockClient.customers.delete).mockRejectedValue(
+				new Error("Internal server error"),
+			);
+
+			const ctx = { context: { logger: { error: vi.fn() } } } as any;
+			const hook = onUserDelete(options);
+
+			// Should not throw, just log the error
+			await hook(mockUser, ctx);
+
+			expect(ctx.context.logger.error).toHaveBeenCalledWith(
+				"Polar customer delete failed. Error: Internal server error",
 			);
 		});
 	});

--- a/packages/polar-betterauth/src/__tests__/utils/mocks.ts
+++ b/packages/polar-betterauth/src/__tests__/utils/mocks.ts
@@ -20,6 +20,7 @@ export const createMockPolarClient = (): Polar =>
 			get: vi.fn(),
 			getStateExternal: vi.fn(),
 			list: vi.fn(),
+			delete: vi.fn(),
 		},
 		customerSessions: {
 			create: vi.fn(),

--- a/packages/polar-betterauth/src/hooks/customer.ts
+++ b/packages/polar-betterauth/src/hooks/customer.ts
@@ -133,6 +133,7 @@ export const onUserDelete =
 					if (existingCustomer) {
 						await options.client.customers.delete({
 							id: existingCustomer.id,
+							anonymize: options.anonymizeCustomerOnDelete ?? false,
 						});
 					}
 				}

--- a/packages/polar-betterauth/src/types.ts
+++ b/packages/polar-betterauth/src/types.ts
@@ -37,6 +37,13 @@ export interface PolarOptions {
 	 */
 	createCustomerOnSignUp?: boolean;
 	/**
+	 * Also anonymize the Polar customer's personal data (hashed email and name,
+	 * cleared billing address, removed OAuth data) for GDPR compliance when the
+	 * customer is deleted on user deletion. Only applies when
+	 * `createCustomerOnSignUp` is enabled.
+	 */
+	anonymizeCustomerOnDelete?: boolean;
+	/**
 	 * A custom function to get the customer create
 	 * params
 	 * @param data - data containing user and session


### PR DESCRIPTION
## What

Adds an opt-in `anonymizeCustomerOnDelete` option to `PolarOptions` (default
`false`). When enabled, the `onUserDelete` hook calls
`customers.delete({ id, anonymize: true })` so the Polar customer's personal
data (hashed email and name, cleared billing address, removed OAuth data) is
anonymized for GDPR compliance instead of a plain delete. Only applies when
`createCustomerOnSignUp` is enabled, since that gates the delete hook.

## Why

Today `onUserDelete` does a plain `customers.delete({ id })`. Per Polar's API
docs, that clears `external_id` but "the customer's information will
nonetheless be retained for historic orders and subscriptions". Apps built on
this plugin have no way to reach `anonymize: true`, so they can't fully honour
a GDPR Art. 17 erasure request for the Polar customer when a user deletes their
account.

Default is `false` to match the SDK's `anonymize` default, so it's
non-breaking.

## How

- `types.ts`: new `anonymizeCustomerOnDelete?: boolean` on `PolarOptions`.
- `hooks/customer.ts`: threaded into the existing `customers.delete` call
  (`anonymize: options.anonymizeCustomerOnDelete ?? false`).
- `README.md`: documented under Optional Options.
- Tests: first unit tests for `onUserDelete`, plus the missing
  `customers.delete` mock stub.
- Changeset: minor bump.

Note that `anonymize: true` retains the customer's `external_id` (a plain
delete clears it), so an anonymized customer can't be recreated under the same
`external_id`.

## Testing

- `pnpm --filter @polar-sh/better-auth test` — 105 passing (6 new `onUserDelete` tests)
- `pnpm --filter @polar-sh/better-auth build` — succeeds (incl. DTS)
- `biome check ./src` — clean
